### PR TITLE
Add "Use reforge stats" to setting

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -1343,14 +1343,6 @@ window.jQuery = $;
               </div>
             </div>
           </div>
-
-          <div class="reforgeSwitch">
-            Use reforged stats
-            <div class="switch">
-              <input id="heroesTabUseReforgedStats" type="checkbox" class="switch-input" checked />
-              <label for="heroesTabUseReforgedStats" class="switch-label"></label>
-            </div>
-          </div>
         </div>
 
 
@@ -1579,6 +1571,16 @@ window.jQuery = $;
           </div>
           <div class="switchText">
             Use rage set bonus for damage optimization
+          </div>
+        </div>
+
+        <div class="toggleRow">
+          <div class="switch">
+            <input id="settingUseReforgeStats" type="checkbox" class="switch-input" />
+            <label for="settingUseReforgeStats" class="switch-label"></label>
+          </div>
+          <div class="switchText">
+            Use reforge stats for heroes page
           </div>
         </div>
 

--- a/app/js/lib/settings.js
+++ b/app/js/lib/settings.js
@@ -19,6 +19,7 @@ module.exports = {
             'settingUnlockOnUnequip',
             'settingMaxResults',
             'settingRageSet',
+            'settingUseReforgeStats',
         ];
 
         $('#optionsExcludeGearFrom').change(module.exports.saveSettings)
@@ -66,6 +67,7 @@ module.exports = {
         return {
             settingUnlockOnUnequip: true,
             settingRageSet: true,
+            settingUseReforgeStats: true,
             settingMaxResults: 5_000_000,
             settingDefaultPath: defaultPath,
             settingExcludeEquipped: []
@@ -81,6 +83,7 @@ module.exports = {
 
         document.getElementById('settingUnlockOnUnequip').checked = settings.settingUnlockOnUnequip;
         document.getElementById('settingRageSet').checked = settings.settingRageSet;
+        document.getElementById('settingUseReforgeStats').checked = settings.settingUseReforgeStats;
         pathOverride = settings.settingDefaultPath;
 
         if (settings.settingMaxResults) {
@@ -104,6 +107,7 @@ module.exports = {
         const settings = {
             settingUnlockOnUnequip: document.getElementById('settingUnlockOnUnequip').checked,
             settingRageSet: document.getElementById('settingRageSet').checked,
+            settingUseReforgeStats: document.getElementById('settingUseReforgeStats').checked,
             settingMaxResults: parseInt(document.getElementById('settingMaxResults').value || 5_000_000),
             settingDefaultPath: pathOverride ? pathOverride : defaultPath,
             settingExcludeEquipped: $('#optionsExcludeGearFrom').multipleSelect('getSelects')

--- a/app/js/lib/tabs/heroesTab.js
+++ b/app/js/lib/tabs/heroesTab.js
@@ -42,8 +42,8 @@ module.exports = {
             addHero(id);
         });
 
-        document.getElementById('heroesTabUseReforgedStats').addEventListener("change", async () => {
-            useReforgedStats = document.getElementById('heroesTabUseReforgedStats').checked;
+        document.getElementById('settingUseReforgeStats').addEventListener("change", async () => {
+            useReforgedStats = document.getElementById('settingUseReforgeStats').checked;
             console.log("REFORGE CHANGE TO " + useReforgedStats);
             redrawGrid();
             clearPreview();

--- a/backend/src/main/java/com/fribbels/request/SetSettingsRequest.java
+++ b/backend/src/main/java/com/fribbels/request/SetSettingsRequest.java
@@ -20,5 +20,6 @@ public class SetSettingsRequest extends Request {
 
     private boolean settingUnlockOnUnequip;
     private boolean settingRageSet;
+    private boolean settingUseReforgeStats;
     private Integer settingMaxResults;
 }


### PR DESCRIPTION
Idea for making the "Use reforge stats" toggle saveable.
I unfortunately don't actually know how to run the optimizer from source (some dev instructions might be nice?), so I don't know if this works as intended. As such, this is more of an idea of how this might look.