### PR TITLE
check for python3 if no py or python

### DIFF
--- a/app/js/lib/scanner.js
+++ b/app/js/lib/scanner.js
@@ -261,24 +261,17 @@ var processes = [];
 // }
 
 function findcommand() {
-    if (Files.isMac()) {
-        console.log("Detecting python on mac, using python");
-        return;
-    } else {
-        command = 'py'
-    }
-
-    console.log("Detecting python, using py for now");
-    try {
-        findCommandSpawn = childProcess.spawn('py');
-        findCommandSpawn.on('error', function(err){
-            console.warn("Error spawning python detector, using python instead", err)
-            command = 'python'
-        })
-    } catch (e) {
-        console.warn("Error trying to detect py, using python instead", e)
-        command = 'python';
-    }
+    const commands = ["py", "python", "python3"];
+    commands.every((command) => {
+        const { error, status } = childProcess.spawnSync(command);
+        if (error || status !== 0) {
+            console.warn(`Error spawning ${command}`);
+            return true;
+        } else {
+            console.log(`Using ${command}`);
+            global.command = command;
+        }
+    });
 }
 
 async function finishedReading(data, scanType) {


### PR DESCRIPTION
Fix for: https://github.com/fribbels/Fribbels-Epic-7-Optimizer/issues/144

Mac OS X 12.3.1 removed built-in Python 2 as well as the `python` command.  In my case, I had `python3` installed and used pyenv to restore my `python` command, but node still can't find `python`.

This PR adds a `python3` check if neither `py` nor `python` are found.  I switched to `childProcess.spawnSync` to avoid adding on more nesting.

Tested on Mac OS 12.3.1:
<img width="244" alt="Screen Shot 2022-05-06 at 11 36 14 AM" src="https://user-images.githubusercontent.com/6818506/167201645-211bae68-1110-45a1-8125-08429c285bc3.png">

and Windows 10:
![Capture](https://user-images.githubusercontent.com/6818506/167201699-b8ed82a6-2f31-40cb-ace0-1f28e934bf0e.PNG)
 