### PR TITLE
Resolves #50. Force sniff all interfaces

### DIFF
--- a/data/py/scanner.py
+++ b/data/py/scanner.py
@@ -53,25 +53,23 @@ def check_packet(packet, index):
                 # if 'F' in packet[TCP].flags:
                 #     try_buffer(currAck)
 
-def thread_sniff(i, index):
-    try:
-        sniff(iface=i, prn=lambda x: check_packet(x, index), filter="tcp and ( port 3333 )", session=TCPSession)
-    except:
-        pass
-
-index = 0
-for i in list(conf.ifaces.data.values()):
-    try:
-        x = threading.Thread(target=thread_sniff, args=(i, index,))
-        x.daemon = True;
-        x.start()
-
-        index = index + 1
-    except:
-        pass
-
 def terminate():
     os._exit(0)
+
+def thread_sniff():
+    try:
+        # EpicSeven traffic was confirmed to travel over tcp port 3333 via Wireshark
+        # Omitting sniff() iface parameter to force all interfaces to be sniffed.
+        # This may lead to more processing but prevents needing to specify an network interface manually in some cases.
+        sniff(prn=lambda x: check_packet(x), filter="tcp and ( port 3333 )", session=TCPSession)
+    except:
+        pass
+
+
+x = threading.Thread(target=thread_sniff)
+x.daemon = True;
+x.start()
+
 
 t = threading.Timer(3600.0, terminate)
 t.start()


### PR DESCRIPTION
Based off https://stackoverflow.com/questions/31106720/scapy-sniff-function-not-catching-any-packets

Not sure if you are interested, but I think I nailed a simpler fix (from the user experience, at least). 

This resolves the problem by removing the iface parameter on the sniff function. I would expect this to not negatively affect unaffected users and to help users who are affected by the 'Failed to read items' error.

As to why this works, I think that the list of values in `conf.ifaces.data.values()` may have provided invalid interfaces and that leads to an exception inside the thread that sniffs (which by design, in python, is a silent exception that you cannot retrieve easily on the main thread).

The issue therefore is avoided by not specifying an iface value, which may be potentially invalid.

-----

I also removed some unused variables from this code section.




Please let me know if you have any comments. Kinda new to pull requests! 😊
