### PR TITLE
Fix name property for Artifact Prelude to a New Era

### DIFF
--- a/data/cache/artifactdata.json
+++ b/data/cache/artifactdata.json
@@ -1671,7 +1671,7 @@
       "image": "https://raw.githubusercontent.com/fribbels/Fribbels-Epic-7-Optimizer/main/app/assets/blank.png",
       "thumbnail": "https://raw.githubusercontent.com/fribbels/Fribbels-Epic-7-Optimizer/main/app/assets/blank.png"
     },
-    "name": "Portrait of the Saviors",
+    "name": "Prelude to a New Era",
     "rarity": 4,
     "role": "",
     "stats": {


### PR DESCRIPTION
Fixes "Portrait of the Saviors" being shown twice, while one of them is supposed to be "Prelude to a New Era"