### PR TITLE
Make hero, gear and builds grids resizable

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -1513,16 +1513,16 @@ body.dark-theme input {
   width: 100%;
 }
 .heroesTableContainer {
-  min-height: 370px;
-  height: 370px;
+  min-height: 200px;
+  height: 200px;
   flex-grow: 1;
   margin-top: 6px;
   resize: vertical;
   overflow: hidden;
 }
 .buildsTableContainer {
-  min-height: 160px;
-  height: 160px;
+  min-height: 193px;
+  height: 193px;
   flex-grow: 0.2;
   margin-bottom: 5px;
   resize: vertical;

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -966,6 +966,7 @@ input[type=number]::-webkit-outer-spin-button {
   padding-bottom: 5px;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
 }
 .tooltipImageLeft {
   height: 14px;
@@ -1491,38 +1492,41 @@ body.dark-theme input {
 }
 .gearGridContainer {
   flex-grow: 2;
-  min-height: 340px;
+  min-height: 350px;
   display: flex;
+  resize: vertical;
+  overflow: hidden;
 }
 #gear-grid {
   width: 100%;
-  height: 100%;
 }
 .gearSectionContainer {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   width: 100%;
-  height: 94%
 }
 .heroesSectionContainer {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   width: 100%;
-  height: 94%
 }
 .heroesTableContainer {
   min-height: 370px;
   height: 370px;
   flex-grow: 1;
   margin-top: 6px;
+  resize: vertical;
+  overflow: hidden;
 }
 .buildsTableContainer {
   min-height: 160px;
   height: 160px;
   flex-grow: 0.2;
   margin-bottom: 5px;
+  resize: vertical;
+  overflow: hidden;
 }
 #heroes-table {
   height: 100%;


### PR DESCRIPTION
As per the title, we are setting the resize: vertical properties to make make hero, gear and builds grids resizable.
Specially for heroes with large collections of builds this is a nice QoL imo.
Already tested with a yarn dev / yarn package-win.

This is enabling the default bottom right html resize element handle to increase size whilst respecting the min-height. The handle looks good enough by default.

One could optionally further remove the min-height parameter to collapse full elements but that seemed unnecessary and prone to visual bugs.

Example:

![image](https://github.com/fribbels/Fribbels-Epic-7-Optimizer/assets/29668777/7df5683c-cfe0-4e1b-a756-77a1395d709d)
![image](https://github.com/fribbels/Fribbels-Epic-7-Optimizer/assets/29668777/0978e5b6-fce7-4746-99cd-95209ecf3741)
